### PR TITLE
Fix GBIF map links

### DIFF
--- a/ckanext/gbif/theme/templates/record/gbif.html
+++ b/ckanext/gbif/theme/templates/record/gbif.html
@@ -135,7 +135,7 @@
 
                     <tr>
                         <td><strong>Coordinates</strong></td>
-                        <td><a href="http://www.gbif.org/gbif_record/{{ gbif_record['id'] }}#map" target="_blank" rel="nofollow">{{ gbif_record['decimallongitude'] }}, {{ gbif_record['decimallatitude'] }}</a></td>
+                        <td><a href="http://www.gbif.org/occurrence/{{ gbif_record['id'] }}" target="_blank" rel="nofollow">{{ gbif_record['decimallongitude'] }}, {{ gbif_record['decimallatitude'] }}</a></td>
                     </tr>
 
                 {% endif %}


### PR DESCRIPTION
The page `gbif_record/` doesn't exist anymore so given that the map is at the top of an occurrence page we'll just link to that.

Closes https://github.com/NaturalHistoryMuseum/data-portal/issues/111