### PR TITLE
Add a timeout to stop the GBIF API requests hanging forever

### DIFF
--- a/ckanext/gbif/logic/action.py
+++ b/ckanext/gbif/logic/action.py
@@ -25,6 +25,8 @@ def gbif_record_show(context, data_dict):
         raise toolkit.ObjectNotFound("GBIF request timed out")
     # if there was an error getting the record, raise a not found error
     if 400 <= response.status_code < 600:
-        raise toolkit.ObjectNotFound
+        raise toolkit.ObjectNotFound(
+            f"GBIF request failed with code {response.status_code}"
+        )
     else:
         return response.json()

--- a/ckanext/gbif/logic/action.py
+++ b/ckanext/gbif/logic/action.py
@@ -21,7 +21,7 @@ def gbif_record_show(context, data_dict):
         response = requests.get(
             f"https://api.gbif.org/v1/occurrence/{gbif_id}", timeout=5
         )
-    except requests.exceptions.Timeout:
+    except requests.Timeout:
         raise toolkit.ObjectNotFound("GBIF request timed out")
     # if there was an error getting the record, raise a not found error
     if 400 <= response.status_code < 600:

--- a/ckanext/gbif/logic/action.py
+++ b/ckanext/gbif/logic/action.py
@@ -16,8 +16,13 @@ def gbif_record_show(context, data_dict):
     :param context: CKAN context
     :param data_dict: dict of parameters, only one is required: gbif_id
     """
-    gbif_id = toolkit.get_or_bust(data_dict, 'gbif_id')
-    response = requests.get(f'https://api.gbif.org/v1/occurrence/{gbif_id}')
+    gbif_id = toolkit.get_or_bust(data_dict, "gbif_id")
+    try:
+        response = requests.get(
+            f"https://api.gbif.org/v1/occurrence/{gbif_id}", timeout=5
+        )
+    except requests.exceptions.Timeout:
+        raise toolkit.ObjectNotFound("GBIF request timed out")
     # if there was an error getting the record, raise a not found error
     if 400 <= response.status_code < 600:
         raise toolkit.ObjectNotFound

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -32,6 +32,9 @@ class TestGBIFRecordShow:
 
     def test_timeout(self, requests_mock):
         gbif_id = "test"
+        # we mock the entire requests module so we need to put the Timeout class back
+        # before we use it
+        requests_mock.Timeout = requests.Timeout
         requests_mock.configure_mock(get=MagicMock(side_effect=requests.Timeout()))
         with pytest.raises(toolkit.ObjectNotFound):
             gbif_record_show(MagicMock(), dict(gbif_id=gbif_id))

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -15,7 +15,7 @@ class TestGBIFRecordShow:
         record = gbif_record_show(MagicMock(), dict(gbif_id=gbif_id))
         assert record == mock_response.json()
         assert requests_mock.get.call_args == call(
-            f'https://api.gbif.org/v1/occurrence/{gbif_id}'
+            f'https://api.gbif.org/v1/occurrence/{gbif_id}', timeout=5
         )
 
     def test_failure(self, requests_mock):
@@ -25,7 +25,7 @@ class TestGBIFRecordShow:
         with pytest.raises(toolkit.ObjectNotFound):
             gbif_record_show(MagicMock(), dict(gbif_id=gbif_id))
         assert requests_mock.get.call_args == call(
-            f'https://api.gbif.org/v1/occurrence/{gbif_id}'
+            f'https://api.gbif.org/v1/occurrence/{gbif_id}', timeout=5
         )
 
     def test_missing_gbif_id(self, requests_mock):
@@ -46,5 +46,5 @@ class TestGBIFRecordShow:
         record = toolkit.get_action('gbif_record_show')({}, dict(gbif_id=gbif_id))
         assert record == mock_response.json()
         assert requests_mock.get.call_args == call(
-            f'https://api.gbif.org/v1/occurrence/{gbif_id}'
+            f'https://api.gbif.org/v1/occurrence/{gbif_id}', timeout=5
         )

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -31,12 +31,12 @@ class TestGBIFRecordShow:
         )
 
     def test_timeout(self, requests_mock):
-        gbif_id = 'test'
-        requests_mock.configure_mock(get=MagicMock(side_effect=requests.Timeout))
+        gbif_id = "test"
+        requests_mock.configure_mock(get=MagicMock(side_effect=requests.Timeout()))
         with pytest.raises(toolkit.ObjectNotFound):
             gbif_record_show(MagicMock(), dict(gbif_id=gbif_id))
         assert requests_mock.get.call_args == call(
-            f'https://api.gbif.org/v1/occurrence/{gbif_id}', timeout=5
+            f"https://api.gbif.org/v1/occurrence/{gbif_id}", timeout=5
         )
 
     def test_missing_gbif_id(self, requests_mock):


### PR DESCRIPTION
When loading a record page, we make a request to see if there is an available GBIF version of the record (if the record has a `gbifID` field). This request to the GBIF API is done with no timeout so it hangs if there is a problem getting to GBIF or if GBIF are having issues. This change adds a timeout to this.

This is a hot fix as we are currently having issues making requests to GBIF so we're hanging a lot and it's causing site instability.